### PR TITLE
Herokuでアバター画像, ピンの画像をアップロードできるようにする

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -192,7 +192,10 @@ document.addEventListener('turbolinks:load', async () => {
         formData.append('pin[title]', inputTitle);
         formData.append('pin[description]', inputDescription);
         formData.append('pin[lonlat]', inputLonlat);
-        formData.append('pin[image]', inputImage);
+
+        if (inputImage) {
+          formData.append('pin[image]', inputImage);
+        }
 
         const postRequest = await fetch(`${location.href}/pins`, {
           method: 'POST',


### PR DESCRIPTION
- [x] ユーザー新規作成でアバター画像を登録できることを確認

- [x] アバター画像を編集できることを確認

- [x] `maps#show` にて、ピン作成時に画像をPOSTできることを確認（画像を添付しない場合もエラーが発生しないことを確認）

close #70 

URL: https://rails-heroku-sharemap.herokuapp.com